### PR TITLE
Simplified print call

### DIFF
--- a/fileWriter.py
+++ b/fileWriter.py
@@ -22,4 +22,4 @@ with open("Output.txt", "w", encoding='UTF-8') as text_file:
             #if "|" in line[3]:
             #    line[3] = line[3][line[3].index("|") + 1:]
             # noinspection PyTypeChecker
-            print(name + "," + str(r) + "," + str(g) + "," + str(blu), file=text_file)
+            print(name, r, g, blu, sep=',', file=text_file)


### PR DESCRIPTION
Replaced "+ ',' +" occurrences with sep=','.
Removed calls to `str` (unnecessary for print).