### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+beautifulsoup4==4.6.0
+bs4==0.0.1
+certifi==2017.7.27.1
+chardet==3.0.4
+idna==2.5
+oauthlib==2.0.2
+requests==2.18.2
+requests-oauthlib==0.8.0
+six==1.10.0
+tweepy==3.5.0
+urllib3==1.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ certifi==2017.7.27.1
 chardet==3.0.4
 idna==2.5
 oauthlib==2.0.2
+pyserial==3.4
 requests==2.18.2
 requests-oauthlib==0.8.0
 six==1.10.0


### PR DESCRIPTION
Requirements file for pip. Based on running 
```bash
$ pip install bs4 pyserial requests tweepy
$ pip freeze > requirements.txt
``` 
on July 30, 2017 at 18:30 EST.