### PR TITLE
Made socket use more idiomatic via context manager

### DIFF
--- a/send_data.py
+++ b/send_data.py
@@ -1,11 +1,12 @@
 import socket
 
-host = socket.gethostbyname('192.168.1.8')
-port = 8493
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-print(host)
-s.connect((host, port))
-s.sendall(b'v03f0203,f0206,f0811')
-data = s.recv(1024)
-s.close()
-print('Received', repr(data))
+HOST = socket.gethostbyname('192.168.1.8')
+PORT = 8493
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    print(HOST)
+    s.connect((HOST, PORT))
+    s.sendall(b'v03f0203,f0206,f0811')
+    data = s.recv(1024)
+
+print('Received %r' % data)


### PR DESCRIPTION
Used `with` rather than `socket.close()`. The socket can now close itself when it's done, and the steps that require the socket are more explicit. Code adapted from previous version and example from [Python socket docs](https://docs.python.org/3/library/socket.html).